### PR TITLE
Fix divide by zero in ExportArrayOneFileCombine

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -406,18 +406,21 @@ namespace DVISApi
 			// Determine highest frequency
 			int[] options = { 100, 250, 500, 750, 1000 };
 			int highestFrequency = options.Last();
-			foreach (var signal in signalsToIterators)
-			{
-				var list = signal.Value;
-				double sum = 0d;
-				int count = 0;
-				for (int i = 2; i < 10 && i < list.Count; i++)
-				{
-					sum += Math.Round((list[i].TimeStamp - list[i - 1].TimeStamp).TotalMilliseconds);
-					count++;
-				}
+                        foreach (var signal in signalsToIterators)
+                        {
+                                var list = signal.Value;
+                                double sum = 0d;
+                                int count = 0;
+                                for (int i = 2; i < 10 && i < list.Count; i++)
+                                {
+                                        sum += Math.Round((list[i].TimeStamp - list[i - 1].TimeStamp).TotalMilliseconds);
+                                        count++;
+                                }
 
-				int avg = (int)Math.Round(sum / count);
+                                if (count == 0)
+                                        continue;
+
+                                int avg = (int)Math.Round(sum / count);
 				int closest = options.Last();
 				for (int i = 0; i < options.Length; i++)
 				{


### PR DESCRIPTION
## Summary
- prevent divide by zero when calculating average signal period

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845899f13408324a7080a54ab6d2c36