### PR TITLE
Add LaserVolumesControl

### DIFF
--- a/DVISApi.csproj
+++ b/DVISApi.csproj
@@ -75,6 +75,12 @@
     <Compile Include="LaserStatsControl.Designer.cs">
       <DependentUpon>LaserStatsControl.cs</DependentUpon>
     </Compile>
+    <Compile Include="LaserVolumesControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="LaserVolumesControl.Designer.cs">
+      <DependentUpon>LaserVolumesControl.cs</DependentUpon>
+    </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TSPointWebIterator.cs" />

--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -80,6 +80,7 @@
 			this.columnHeaderMsg = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
 			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
 			this.tabPageLaserStats = new System.Windows.Forms.TabPage();
+                        this.tabPageLaserVolumes = new System.Windows.Forms.TabPage();
 			this.groupBox1.SuspendLayout();
 			this.tabControl1.SuspendLayout();
 			this.tabPage1.SuspendLayout();
@@ -142,6 +143,7 @@
 			this.tabControl1.Controls.Add(this.tabPage4);
 			this.tabControl1.Controls.Add(this.tabPageLaserCampaigns);
 			this.tabControl1.Controls.Add(this.tabPageLaserStats);
+                        this.tabControl1.Controls.Add(this.tabPageLaserVolumes);
 			this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
 			this.tabControl1.Location = new System.Drawing.Point(2, 30);
 			this.tabControl1.Margin = new System.Windows.Forms.Padding(7);
@@ -661,6 +663,13 @@
 			this.tabPageLaserStats.TabIndex = 5;
 			this.tabPageLaserStats.Text = "Laser Stats";
 			this.tabPageLaserStats.UseVisualStyleBackColor = true;
+                        // tabPageLaserVolumes
+                        this.tabPageLaserVolumes.Location = new System.Drawing.Point(8, 43);
+                        this.tabPageLaserVolumes.Name = "tabPageLaserVolumes";
+                        this.tabPageLaserVolumes.Size = new System.Drawing.Size(3061, 1371);
+                        this.tabPageLaserVolumes.TabIndex = 6;
+                        this.tabPageLaserVolumes.Text = "Laser Volumes";
+                        this.tabPageLaserVolumes.UseVisualStyleBackColor = true;
 			// 
 			// Form1
 			// 
@@ -743,6 +752,7 @@
 		private System.Windows.Forms.Button buttonCancelPostImage;
 		private System.Windows.Forms.TabPage tabPageLaserCampaigns;
 		private System.Windows.Forms.TabPage tabPageLaserStats;
+                private System.Windows.Forms.TabPage tabPageLaserVolumes;
 	}
 }
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -36,6 +36,9 @@ namespace DVISApi
 			var statsControl = new LaserStatsControl(OnMessage);
 			statsControl.Dock = DockStyle.Fill;
 			tabPageLaserStats.Controls.Add(statsControl);
+                        var volumesControl = new LaserVolumesControl(OnMessage);
+                        volumesControl.Dock = DockStyle.Fill;
+                        tabPageLaserVolumes.Controls.Add(volumesControl);
 
 
 			listViewContextMenu = new ContextMenuStrip();

--- a/LaserVolumesControl.Designer.cs
+++ b/LaserVolumesControl.Designer.cs
@@ -1,0 +1,255 @@
+namespace DVISApi
+{
+    partial class LaserVolumesControl
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        private System.Windows.Forms.TextBox textBoxServer;
+        private System.Windows.Forms.TextBox textBoxVessel;
+        private System.Windows.Forms.TextBox textBoxDateStart;
+        private System.Windows.Forms.TextBox textBoxDateEnd;
+        private System.Windows.Forms.TextBox textBoxDb;
+        private System.Windows.Forms.Button buttonQuery;
+        private System.Windows.Forms.Button buttonCancel;
+        private System.Windows.Forms.Button buttonSaveCsv;
+        private System.Windows.Forms.ListView listViewVolumes;
+        private System.Windows.Forms.Label labelServer;
+        private System.Windows.Forms.Label labelVessel;
+        private System.Windows.Forms.Label labelDateStart;
+        private System.Windows.Forms.Label labelDateEnd;
+        private System.Windows.Forms.Label labelDb;
+        private System.Windows.Forms.CheckBox checkBoxIncludeVessel;
+        private System.Windows.Forms.TextBox textBoxFilterString;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.labelServer = new System.Windows.Forms.Label();
+            this.labelVessel = new System.Windows.Forms.Label();
+            this.labelDateStart = new System.Windows.Forms.Label();
+            this.labelDateEnd = new System.Windows.Forms.Label();
+            this.labelDb = new System.Windows.Forms.Label();
+            this.textBoxServer = new System.Windows.Forms.TextBox();
+            this.textBoxVessel = new System.Windows.Forms.TextBox();
+            this.textBoxDateStart = new System.Windows.Forms.TextBox();
+            this.textBoxDateEnd = new System.Windows.Forms.TextBox();
+            this.textBoxDb = new System.Windows.Forms.TextBox();
+            this.checkBoxIncludeVessel = new System.Windows.Forms.CheckBox();
+            this.buttonQuery = new System.Windows.Forms.Button();
+            this.buttonCancel = new System.Windows.Forms.Button();
+            this.buttonSaveCsv = new System.Windows.Forms.Button();
+            this.textBoxFilterString = new System.Windows.Forms.TextBox();
+            this.listViewVolumes = new System.Windows.Forms.ListView();
+            this.SuspendLayout();
+            // 
+            // labelServer
+            // 
+            this.labelServer.AutoSize = true;
+            this.labelServer.Location = new System.Drawing.Point(10, 10);
+            this.labelServer.Name = "labelServer";
+            this.labelServer.Size = new System.Drawing.Size(41, 15);
+            this.labelServer.TabIndex = 0;
+            this.labelServer.Text = "Server";
+            // 
+            // labelVessel
+            // 
+            this.labelVessel.AutoSize = true;
+            this.labelVessel.Location = new System.Drawing.Point(10, 40);
+            this.labelVessel.Name = "labelVessel";
+            this.labelVessel.Size = new System.Drawing.Size(42, 15);
+            this.labelVessel.TabIndex = 1;
+            this.labelVessel.Text = "Vessel";
+            // 
+            // labelDateStart
+            // 
+            this.labelDateStart.AutoSize = true;
+            this.labelDateStart.Location = new System.Drawing.Point(10, 70);
+            this.labelDateStart.Name = "labelDateStart";
+            this.labelDateStart.Size = new System.Drawing.Size(63, 15);
+            this.labelDateStart.TabIndex = 2;
+            this.labelDateStart.Text = "Date Start";
+            // 
+            // labelDateEnd
+            // 
+            this.labelDateEnd.AutoSize = true;
+            this.labelDateEnd.Location = new System.Drawing.Point(10, 100);
+            this.labelDateEnd.Name = "labelDateEnd";
+            this.labelDateEnd.Size = new System.Drawing.Size(61, 15);
+            this.labelDateEnd.TabIndex = 3;
+            this.labelDateEnd.Text = "Date End";
+            // 
+            // labelDb
+            // 
+            this.labelDb.AutoSize = true;
+            this.labelDb.Location = new System.Drawing.Point(10, 130);
+            this.labelDb.Name = "labelDb";
+            this.labelDb.Size = new System.Drawing.Size(24, 15);
+            this.labelDb.TabIndex = 4;
+            this.labelDb.Text = "DB";
+            // 
+            // 
+            // 
+            // textBoxServer
+            // 
+            this.textBoxServer.Location = new System.Drawing.Point(80, 10);
+            this.textBoxServer.Name = "textBoxServer";
+            this.textBoxServer.Size = new System.Drawing.Size(200, 23);
+            this.textBoxServer.TabIndex = 6;
+            this.textBoxServer.Text = "10.28.13.71:5123";
+            // 
+            // textBoxVessel
+            // 
+            this.textBoxVessel.Location = new System.Drawing.Point(80, 40);
+            this.textBoxVessel.Name = "textBoxVessel";
+            this.textBoxVessel.Size = new System.Drawing.Size(200, 23);
+            this.textBoxVessel.TabIndex = 7;
+            // 
+            // textBoxDateStart
+            // 
+            this.textBoxDateStart.Location = new System.Drawing.Point(80, 70);
+            this.textBoxDateStart.Name = "textBoxDateStart";
+            this.textBoxDateStart.Size = new System.Drawing.Size(200, 23);
+            this.textBoxDateStart.TabIndex = 8;
+            // 
+            // textBoxDateEnd
+            // 
+            this.textBoxDateEnd.Location = new System.Drawing.Point(80, 100);
+            this.textBoxDateEnd.Name = "textBoxDateEnd";
+            this.textBoxDateEnd.Size = new System.Drawing.Size(200, 23);
+            this.textBoxDateEnd.TabIndex = 9;
+            // 
+            // textBoxDb
+            // 
+            this.textBoxDb.Location = new System.Drawing.Point(80, 130);
+            this.textBoxDb.Name = "textBoxDb";
+            this.textBoxDb.Size = new System.Drawing.Size(200, 23);
+            this.textBoxDb.TabIndex = 10;
+            // 
+            // 
+                "Average",
+                "Average10cmCylinderThinnestMargin",
+                "Average10cmCylinderThickestMargin",
+                "Average10cmCylinder",
+                "AverageMax10cmCylinder",
+                "EntireRegionAverageMargin",
+                "ThinnestPointMargin",
+                "NumPointsInRegion",
+                "PercentCoverage"});
+            // 
+            // checkBoxIncludeVessel
+            // 
+            this.checkBoxIncludeVessel.AutoSize = true;
+            this.checkBoxIncludeVessel.Checked = true;
+            this.checkBoxIncludeVessel.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkBoxIncludeVessel.Location = new System.Drawing.Point(285, 42);
+            this.checkBoxIncludeVessel.Name = "checkBoxIncludeVessel";
+            this.checkBoxIncludeVessel.Size = new System.Drawing.Size(65, 19);
+            this.checkBoxIncludeVessel.TabIndex = 12;
+            this.checkBoxIncludeVessel.Text = "Include";
+            this.checkBoxIncludeVessel.UseVisualStyleBackColor = true;
+            // 
+            // buttonQuery
+            // 
+            this.buttonQuery.Location = new System.Drawing.Point(80, 190);
+            this.buttonQuery.Name = "buttonQuery";
+            this.buttonQuery.Size = new System.Drawing.Size(100, 23);
+            this.buttonQuery.TabIndex = 13;
+            this.buttonQuery.Text = "Query";
+            this.buttonQuery.UseVisualStyleBackColor = true;
+            this.buttonQuery.Click += new System.EventHandler(this.ButtonQuery_Click);
+            // 
+            // buttonCancel
+            // 
+            this.buttonCancel.Enabled = false;
+            this.buttonCancel.Location = new System.Drawing.Point(190, 190);
+            this.buttonCancel.Name = "buttonCancel";
+            this.buttonCancel.Size = new System.Drawing.Size(100, 23);
+            this.buttonCancel.TabIndex = 14;
+            this.buttonCancel.Text = "Cancel";
+            this.buttonCancel.UseVisualStyleBackColor = true;
+            this.buttonCancel.Click += new System.EventHandler(this.ButtonCancel_Click);
+            // 
+            // buttonSaveCsv
+            // 
+            this.buttonSaveCsv.Enabled = false;
+            this.buttonSaveCsv.Location = new System.Drawing.Point(300, 190);
+            this.buttonSaveCsv.Name = "buttonSaveCsv";
+            this.buttonSaveCsv.Size = new System.Drawing.Size(120, 23);
+            this.buttonSaveCsv.TabIndex = 15;
+            this.buttonSaveCsv.Text = "Save to CSV";
+            this.buttonSaveCsv.UseVisualStyleBackColor = true;
+            this.buttonSaveCsv.Click += new System.EventHandler(this.ButtonSaveCsv_Click);
+            // 
+            // textBoxFilterString
+            // 
+            this.textBoxFilterString.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+                        | System.Windows.Forms.AnchorStyles.Right)));
+            this.textBoxFilterString.Location = new System.Drawing.Point(10, 218);
+            this.textBoxFilterString.Name = "textBoxFilterString";
+            this.textBoxFilterString.ReadOnly = true;
+            this.textBoxFilterString.Size = new System.Drawing.Size(0, 23);
+            this.textBoxFilterString.TabIndex = 16;
+            // 
+            // listViewVolumes
+            // 
+            this.listViewVolumes.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+                        | System.Windows.Forms.AnchorStyles.Right)));
+            this.listViewVolumes.FullRowSelect = true;
+            this.listViewVolumes.GridLines = true;
+            this.listViewVolumes.Location = new System.Drawing.Point(10, 246);
+            this.listViewVolumes.Name = "listViewVolumes";
+            this.listViewVolumes.Size = new System.Drawing.Size(0, 0);
+            this.listViewVolumes.TabIndex = 17;
+            this.listViewVolumes.UseCompatibleStateImageBehavior = false;
+            this.listViewVolumes.View = System.Windows.Forms.View.Details;
+            // 
+            // LaserVolumesControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.listViewVolumes);
+            this.Controls.Add(this.textBoxFilterString);
+            this.Controls.Add(this.buttonSaveCsv);
+            this.Controls.Add(this.buttonCancel);
+            this.Controls.Add(this.buttonQuery);
+            this.Controls.Add(this.checkBoxIncludeVessel);
+            this.Controls.Add(this.textBoxDb);
+            this.Controls.Add(this.textBoxDateEnd);
+            this.Controls.Add(this.textBoxDateStart);
+            this.Controls.Add(this.textBoxVessel);
+            this.Controls.Add(this.textBoxServer);
+            this.Controls.Add(this.labelDb);
+            this.Controls.Add(this.labelDateEnd);
+            this.Controls.Add(this.labelDateStart);
+            this.Controls.Add(this.labelVessel);
+            this.Controls.Add(this.labelServer);
+            this.Name = "LaserVolumesControl";
+            this.Size = new System.Drawing.Size(500, 400);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+    }
+}

--- a/LaserVolumesControl.cs
+++ b/LaserVolumesControl.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace DVISApi
+{
+    public partial class LaserVolumesControl : UserControl
+    {
+        readonly Action<string> _onMsg;
+
+
+        CancellationTokenSource _cts;
+        int _sortColumn = -1;
+        SortOrder _sortOrder = SortOrder.None;
+        string _lastCsvResult = null;
+
+        public LaserVolumesControl(Action<string> onMsg)
+        {
+            _onMsg = onMsg;
+            InitializeComponent();
+            InitializeAdditionalComponents();
+            listViewVolumes.ColumnClick += ListViewVolumes_ColumnClick;
+        }
+
+        void InitializeAdditionalComponents()
+        {
+            Action layoutControls = () =>
+            {
+                int topOfList = textBoxFilterString.Bottom + 5;
+                int listWidth = this.Width - 20;
+                int listHeight = this.Height - topOfList - 10;
+                listViewVolumes.SetBounds(10, topOfList, listWidth, listHeight);
+
+                buttonSaveCsv.Top = buttonQuery.Top;
+                buttonSaveCsv.Left = buttonCancel.Right + 10;
+
+                textBoxFilterString.Width = listWidth;
+                textBoxFilterString.Top = buttonQuery.Bottom + 5;
+            };
+            this.Resize += (s, e) => layoutControls();
+            layoutControls();
+
+            textBoxServer.TextChanged += (s, e) => UpdateFilterString();
+            textBoxVessel.TextChanged += (s, e) => UpdateFilterString();
+            checkBoxIncludeVessel.CheckedChanged += (s, e) => UpdateFilterString();
+            textBoxDateStart.TextChanged += (s, e) => UpdateFilterString();
+            textBoxDateEnd.TextChanged += (s, e) => UpdateFilterString();
+            textBoxDb.TextChanged += (s, e) => UpdateFilterString();
+
+            LoadSettings();
+            UpdateFilterString();
+        }
+
+        async void ButtonQuery_Click(object sender, EventArgs e)
+        {
+            SaveSettings();
+            OnMessage("ButtonQuery_Click");
+            DisableAllControls();
+            buttonCancel.Enabled = true;
+            _cts = new CancellationTokenSource();
+            _cts.CancelAfter(TimeSpan.FromMinutes(1));
+
+            try
+            {
+                string server = textBoxServer.Text.Trim();
+                string vessel = textBoxVessel.Text.Trim();
+                string dateStart = textBoxDateStart.Text.Trim();
+                string dateEnd = textBoxDateEnd.Text.Trim();
+                string db = textBoxDb.Text.Trim();
+
+                var url = new StringBuilder();
+                url.Append("http://").Append(server).Append("/api/laser/volumes");
+
+                var parameters = new List<string>();
+                if (checkBoxIncludeVessel.Checked && !string.IsNullOrWhiteSpace(vessel))
+                    parameters.Add("vessel=" + Uri.EscapeDataString(vessel));
+                if (!string.IsNullOrEmpty(dateStart))
+                    parameters.Add("dateStart=" + Uri.EscapeDataString(dateStart));
+                if (!string.IsNullOrEmpty(dateEnd))
+                    parameters.Add("dateEnd=" + Uri.EscapeDataString(dateEnd));
+                if (!string.IsNullOrEmpty(db))
+                    parameters.Add("db=" + Uri.EscapeDataString(db));
+
+                if (parameters.Count > 0)
+                    url.Append("?").Append(string.Join("&", parameters));
+
+                using (var client = new HttpClient())
+                {
+                    OnMessage("Querying API: " + url.ToString());
+                    var sw = System.Diagnostics.Stopwatch.StartNew();
+                    var response = await client.GetAsync(url.ToString(), _cts.Token);
+                    response.EnsureSuccessStatusCode();
+                    var csv = await response.Content.ReadAsStringAsync();
+
+                    if (!IsCsvData(csv))
+                    {
+                        _lastCsvResult = null;
+                        buttonSaveCsv.Enabled = false;
+                        listViewVolumes.Items.Clear();
+                        listViewVolumes.Columns.Clear();
+                        OnMessage(csv.Trim());
+                    }
+                    else
+                    {
+                        int rowCount = DisplayVolumes(csv);
+                        sw.Stop();
+                        OnMessage(string.Format("Retrieved {0} rows in {1:0.00} seconds", rowCount, sw.Elapsed.TotalSeconds));
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                OnMessage("Request was cancelled or timed out.");
+            }
+            catch (Exception ex)
+            {
+                OnMessage("Error querying API: " + ex.Message);
+            }
+            finally
+            {
+                EnableAllControls();
+                buttonCancel.Enabled = false;
+                _cts = null;
+            }
+        }
+
+        private bool IsCsvData(string data)
+        {
+            if (string.IsNullOrWhiteSpace(data)) return false;
+            if (data.ToLower().Contains("exception")) return false;
+            using (var reader = new StringReader(data))
+            {
+                string header = reader.ReadLine();
+                return header != null && header.Contains(",");
+            }
+        }
+
+        void OnMessage(string s)
+        {
+            if (_onMsg != null) _onMsg(string.Format("LaserVolumesControl: {0}", s));
+        }
+
+        void ButtonCancel_Click(object sender, EventArgs e)
+        {
+            if (_cts != null)
+            {
+                _cts.Cancel();
+            }
+        }
+
+        int DisplayVolumes(string csv)
+        {
+            if (InvokeRequired)
+            {
+                BeginInvoke(new Func<string, int>(DisplayVolumes), csv);
+                return 0;
+            }
+
+            listViewVolumes.Items.Clear();
+            listViewVolumes.Columns.Clear();
+
+            int rowCount = 0;
+            using (var reader = new StringReader(csv))
+            {
+                string header = reader.ReadLine();
+                if (string.IsNullOrWhiteSpace(header)) return 0;
+                var headers = header.Split(',');
+                foreach (var h in headers)
+                    listViewVolumes.Columns.Add(h.Trim(), 100);
+
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if (string.IsNullOrWhiteSpace(line)) continue;
+                    var fields = line.Split(',');
+                    var item = new ListViewItem(fields.Length > 0 ? fields[0] : "");
+                    for (int i = 1; i < headers.Length; i++)
+                        item.SubItems.Add(i < fields.Length ? fields[i] : "");
+                    listViewVolumes.Items.Add(item);
+                    rowCount++;
+                }
+            }
+
+            if (rowCount > 0)
+            {
+                _lastCsvResult = csv;
+                buttonSaveCsv.Enabled = true;
+            }
+            else
+            {
+                _lastCsvResult = null;
+                buttonSaveCsv.Enabled = false;
+            }
+            return rowCount;
+        }
+
+        void DisableAllControls()
+        {
+            foreach (Control c in Controls)
+                if (c != buttonCancel)
+                    c.Enabled = false;
+        }
+
+        void EnableAllControls()
+        {
+            foreach (Control c in Controls)
+                c.Enabled = true;
+        }
+
+        private void LoadSettings()
+        {
+            var settings = Properties.Settings.Default;
+            textBoxServer.Text = settings.LaserVolumesServer;
+            textBoxVessel.Text = settings.LaserVolumesVessel;
+            textBoxDateStart.Text = settings.LaserVolumesDateStart;
+            textBoxDateEnd.Text = settings.LaserVolumesDateEnd;
+            textBoxDb.Text = settings.LaserVolumesDb;
+        }
+
+        private void SaveSettings()
+        {
+            var settings = Properties.Settings.Default;
+            settings.LaserVolumesServer = textBoxServer.Text;
+            settings.LaserVolumesVessel = textBoxVessel.Text;
+            settings.LaserVolumesDateStart = textBoxDateStart.Text;
+            settings.LaserVolumesDateEnd = textBoxDateEnd.Text;
+            settings.LaserVolumesDb = textBoxDb.Text;
+            settings.Save();
+        }
+
+        void ListViewVolumes_ColumnClick(object sender, ColumnClickEventArgs e)
+        {
+            if (e.Column == _sortColumn)
+            {
+                _sortOrder = _sortOrder == SortOrder.Ascending ? SortOrder.Descending : SortOrder.Ascending;
+            }
+            else
+            {
+                _sortColumn = e.Column;
+                _sortOrder = SortOrder.Ascending;
+            }
+            listViewVolumes.ListViewItemSorter = new ListViewItemComparer(_sortColumn, _sortOrder);
+            listViewVolumes.Sort();
+        }
+
+void ButtonSaveCsv_Click(object sender, EventArgs e)
+        {
+            if (string.IsNullOrEmpty(_lastCsvResult))
+                return;
+
+            using (var sfd = new SaveFileDialog())
+            {
+                sfd.Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*";
+                sfd.Title = "Save Volumes CSV";
+                sfd.FileName = "volumes.csv";
+                if (sfd.ShowDialog() == DialogResult.OK)
+                {
+                    try
+                    {
+                        File.WriteAllText(sfd.FileName, _lastCsvResult, Encoding.UTF8);
+                        OnMessage("Saved CSV to: " + sfd.FileName);
+                    }
+                    catch (Exception ex)
+                    {
+                        OnMessage("Error saving CSV: " + ex.Message);
+                    }
+                }
+            }
+        }
+
+        void UpdateFilterString()
+        {
+            string server = textBoxServer.Text.Trim();
+            if (string.IsNullOrEmpty(server))
+            {
+                textBoxFilterString.Text = "";
+                return;
+            }
+
+            var url = new StringBuilder();
+            url.Append("http://").Append(server).Append("/api/laser/volumes");
+
+            var parameters = new List<string>();
+            if (checkBoxIncludeVessel.Checked && !string.IsNullOrWhiteSpace(textBoxVessel.Text))
+                parameters.Add("vessel=" + Uri.EscapeDataString(textBoxVessel.Text.Trim()));
+            if (!string.IsNullOrWhiteSpace(textBoxDateStart.Text))
+                parameters.Add("dateStart=" + Uri.EscapeDataString(textBoxDateStart.Text.Trim()));
+            if (!string.IsNullOrWhiteSpace(textBoxDateEnd.Text))
+                parameters.Add("dateEnd=" + Uri.EscapeDataString(textBoxDateEnd.Text.Trim()));
+            if (!string.IsNullOrWhiteSpace(textBoxDb.Text))
+                parameters.Add("db=" + Uri.EscapeDataString(textBoxDb.Text.Trim()));
+
+            if (parameters.Count > 0)
+                url.Append("?").Append(string.Join("&", parameters));
+
+            textBoxFilterString.Text = url.ToString();
+        }
+
+        class ListViewItemComparer : System.Collections.IComparer
+        {
+            private int col;
+            private SortOrder order;
+
+            public ListViewItemComparer(int column, SortOrder order)
+            {
+                col = column;
+                this.order = order;
+            }
+
+            public int Compare(object x, object y)
+            {
+                string a = ((ListViewItem)x).SubItems[col].Text;
+                string b = ((ListViewItem)y).SubItems[col].Text;
+
+                DateTime da, db;
+                if (DateTime.TryParse(a, out da) && DateTime.TryParse(b, out db))
+                {
+                    int result = DateTime.Compare(da, db);
+                    return order == SortOrder.Ascending ? result : -result;
+                }
+
+                double fa, fb;
+                if (double.TryParse(a, out fa) && double.TryParse(b, out fb))
+                {
+                    int result = fa.CompareTo(fb);
+                    return order == SortOrder.Ascending ? result : -result;
+                }
+
+                int stringResult = string.Compare(a, b, StringComparison.CurrentCultureIgnoreCase);
+                return order == SortOrder.Ascending ? stringResult : -stringResult;
+            }
+        }
+    }
+}

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -278,6 +278,61 @@ namespace DVISApi.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LaserVolumesServer {
+            get {
+                return ((string)(this["LaserVolumesServer"]));
+            }
+            set {
+                this["LaserVolumesServer"] = value;
+            }
+        }
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LaserVolumesVessel {
+            get {
+                return ((string)(this["LaserVolumesVessel"]));
+            }
+            set {
+                this["LaserVolumesVessel"] = value;
+            }
+        }
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LaserVolumesDateStart {
+            get {
+                return ((string)(this["LaserVolumesDateStart"]));
+            }
+            set {
+                this["LaserVolumesDateStart"] = value;
+            }
+        }
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LaserVolumesDateEnd {
+            get {
+                return ((string)(this["LaserVolumesDateEnd"]));
+            }
+            set {
+                this["LaserVolumesDateEnd"] = value;
+            }
+        }
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LaserVolumesDb {
+            get {
+                return ((string)(this["LaserVolumesDb"]));
+            }
+            set {
+                this["LaserVolumesDb"] = value;
+            }
+        }
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string PostImageFile {
             get {
                 return ((string)(this["PostImageFile"]));

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -65,6 +65,21 @@
     <Setting Name="LaserStatsStat" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="LaserVolumesServer" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="LaserVolumesVessel" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="LaserVolumesDateStart" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="LaserVolumesDateEnd" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="LaserVolumesDb" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
     <Setting Name="PostImageFile" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>


### PR DESCRIPTION
## Summary
- create `LaserVolumesControl` user control for querying laser volumes
- persist new settings for laser volume queries
- integrate new control into application UI

## Testing
- `msbuild` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471a70e8cc8324b360cb3fea5cf9d2